### PR TITLE
Add browser action to add/remove manga URLs

### DIFF
--- a/css/popup.css
+++ b/css/popup.css
@@ -58,3 +58,15 @@ body {
 .material-setting {
   background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAABCUlEQVR4AcXSP0oDURDH8e/u2vmnFRFPIQqeQgTRwqCIN7AwINiIIJJsIQTEQhBT6Am0UAQttLGWJZWEoHgCV7L6BBmG2QdhX5fPr/vNTALLYyh2cZIdglzpQZsgL3rwzEAxT9yyzAxtfvSg4JxpVrjjkYiSLVn5xWnKzTrGBJ+4irwzhjryhq80aJJ57QGqRm4Gx8QAJLRM+8Uqxhxd/fUYQaL/8sYsnj0ZNbBSaesw6KAZdrBAT0YZCYIROtJ2mcfY4BunaZHI+olpc9ZQh94HzEhJ6XjtPmqcD1xFeoxibFY+jRolEQ9cs8gUZxS63OeUSZa44Z4o/HlXutSDC4LUKf7TZ5sh+AObx91kL015YwAAAABJRU5ErkJggg==") top left no-repeat;
 }
+
+.material-add {
+  background: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAAHUlEQVR4AWNAgFHwHwhHNWBVhBtSqgETjMbDKAAA6iwzzdTyG+0AAAAASUVORK5CYII=");
+}
+
+.material-done {
+  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAASUlEQVR4AWPADUaBFmnKQxh+MzSQpvw/Q8PwU87KsIohkBTTI4CSvxiCSHAMUPI/UFEQunLCWoLRlBPWglBOpBaYcqK1YCgfBQDw0y1mS9NLDAAAAABJRU5ErkJggg==');
+}
+
+.material-remove {
+  background: url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAQAAABKfvVzAAAAGElEQVR4AWMgDEbBKPiPG1KqAROMglEAAAoWG+UEvH49AAAAAElFTkSuQmCC');
+}

--- a/js/choose_interval.js
+++ b/js/choose_interval.js
@@ -1,13 +1,159 @@
 function openInNewTab() {
-  chrome.tabs.create({
-    url: chrome.runtime.getURL("../options/dashboard.html")
-  });
+	chrome.tabs.create({
+		url: chrome.runtime.getURL("../options/dashboard.html")
+	});
+}
+
+function modifyUrl(add) {
+	console.log("modify"+add);
+	//if add == false, remove
+	chrome.tabs.query({'active': true}, function (tabs) {
+		url = tabs[0].url;
+
+		chrome.storage.local.get("data", function (data) {
+		  // if data doesn't exist yet
+		  if (!data.data) {
+		  	data = {
+		  		data: {
+		  			mangaTags: []
+		  		}
+		  	};
+		  }
+		  var mangaTags = data.data.mangaTags;
+		  if (add) {
+		  	//add tag
+				console.log("before");
+				console.log(mangaTags);
+			  mangaTags.push({
+			  	tag: url
+			  });
+				console.log("afer");
+				console.log(mangaTags);
+			} else {
+				console.log("before");
+				console.log(mangaTags);
+				//remove all items that have tag == url
+				mangaTags = mangaTags.filter(function(item) {
+					return item.tag !== url;
+				});
+				console.log("afer");
+				console.log(mangaTags);
+			}
+			data.data.mangaTags = mangaTags;
+		  updateAddMangaButton(add);
+		  chrome.storage.local.set(data);
+		});
+	});
+}
+
+function addUrl() {
+	modifyUrl(true);
+}
+
+function removeUrl() {
+	modifyUrl(false);
+}
+
+function mouseover() {
+	var title = document.getElementById("add-url-title");
+	var description = document.getElementById("add-url-description");
+	var icon = document.getElementById("add-url-icon");
+
+	var titleRemovePrompt = "Remove Manga";
+	var descriptionRemovePrompt = "Remove the current tab's URL from your manga list";
+
+	title.innerHTML = titleRemovePrompt;
+	description.innerHTML = descriptionRemovePrompt;
+	icon.classList.add("material-remove");
+	icon.classList.remove("material-done");
+	icon.classList.remove("material-add");
+};
+
+function mouseleave() {
+	var title = document.getElementById("add-url-title");
+	var description = document.getElementById("add-url-description");
+	var icon = document.getElementById("add-url-icon");
+
+	var titleAdded = "Manga Added";
+	var descriptionAdded = "This manga is in your manga list.";
+
+	title.innerHTML = titleAdded;
+	description.innerHTML = descriptionAdded;
+
+	icon.classList.add("material-done");
+	icon.classList.remove("material-add");
+	icon.classList.remove("material-remove");
+};
+
+
+function updateAddMangaButton(isMangaAdded) {
+	var titleAdded = "Manga Added";
+	var descriptionAdded = "This manga is in your manga list.";
+	var titleAddPrompt = "Add Manga";
+	var descriptionAddPrompt = "Add the current tab's URL to your manga list";
+
+
+	var addurlbutton = document.getElementById("add-url-button");
+	var title = document.getElementById("add-url-title");
+	var description = document.getElementById("add-url-description");
+	var icon = document.getElementById("add-url-icon");
+
+	if (isMangaAdded) {
+		console.log("manga alr added");
+		title.innerHTML = titleAdded;
+		description.innerHTML = descriptionAdded;
+		icon.classList.add("material-done");
+		icon.classList.remove("material-add");
+		icon.classList.remove("material-remove");
+
+		//change button to detect for 'remove manga' action
+		addurlbutton.removeEventListener('click', addUrl);
+		addurlbutton.addEventListener('click', removeUrl);
+		addurlbutton.addEventListener('mouseover', mouseover);
+		addurlbutton.addEventListener('mouseleave', mouseleave);
+	} else {
+		title.innerHTML = titleAddPrompt;
+		description.innerHTML = descriptionAddPrompt;
+		icon.classList.add("material-add");
+		icon.classList.remove("material-done");
+		icon.classList.remove("material-remove");
+
+		addurlbutton.removeEventListener('click', removeUrl);
+		addurlbutton.removeEventListener('mouseover', mouseover);
+		addurlbutton.removeEventListener('mouseleave', mouseleave);
+		addurlbutton.addEventListener('click', addUrl);
+	}
 }
 
 document.addEventListener('DOMContentLoaded', function () {
-  var settingsbutton = document.getElementById("settings-button");
+	var settingsbutton = document.getElementById("settings-button");
   // console.log(settingsbutton);
   settingsbutton.addEventListener('click', openInNewTab);
+  
+  
+  chrome.storage.local.get("data", function (data) {
+	  // if data doesn't exist yet
+	  if (!data.data) {
+	  	updateAddMangaButton(false);
+	  } else {
+	  	var mangaTags = data.data.mangaTags;
+
+	  	chrome.tabs.query({'active': true}, function (tabs) {
+	  		url = tabs[0].url;
+
+	  		var added = false;
+	  		for (var i = 0; i < mangaTags.length; i++) {
+	  			console.log(mangaTags[i].tag);
+	  			console.log(url);
+	  			if (mangaTags[i].tag == url) {
+	  				added = true;
+	  				break;
+	  			}
+	  		}
+	  		updateAddMangaButton(added);
+	  	});
+	  }
+	});
 });
 var manifest = chrome.runtime.getManifest() || browser.runtime.getManifest();
 document.getElementById("test").innerHTML = 'Manga Notifier <h6>v' + manifest.version;

--- a/popup/choose_interval.html
+++ b/popup/choose_interval.html
@@ -17,6 +17,21 @@
     <div class="popup">
       <div class="popup-body">
         <div class="popup-section">
+		  <div class="area">
+            <div class="area-header area-expandable" id="add-url-button">
+              <div class="area-headerTitle">
+                <div id="add-url-icon" class="area-icon material-add"></div>
+                <div class="area-title"><span id="add-url-title">Add Manga</span></div>
+                <div class="clear"></div>
+              </div>
+              <div class="area-headerDetails">
+                <div class="area-headerDetailsMainColumn">
+                  <div class="area-text"><span id="add-url-description">Add the current tab's URL to your manga list.</span></div>
+                </div>
+              </div>
+            </div>
+            <noscript></noscript>
+          </div>
           <div class="area">
             <div class="area-header area-expandable" id="settings-button">
               <div class="area-headerTitle">


### PR DESCRIPTION
Added a button that appears in extension menu for quick addition/removal of manga URLs.
When the current URL is already added, the button will display "Manga Added" which upon mouse-over will display "Remove Manga".

Here are a few screenshots of the new extension menu.

![image](https://user-images.githubusercontent.com/8487294/31217164-94bfee1e-a9e8-11e7-96c3-48b2ec328f4e.png)
![image](https://user-images.githubusercontent.com/8487294/31217184-9ff0b7c8-a9e8-11e7-96b5-f9709c0d6b0b.png)
![image](https://user-images.githubusercontent.com/8487294/31217201-afe94794-a9e8-11e7-9ebe-e9efc58746b9.png)

