### PR TITLE
Play sound with notification sound extension

### DIFF
--- a/content_scripts/background.js
+++ b/content_scripts/background.js
@@ -13,6 +13,7 @@ function notify(message) {
     "title": data.title,
     "message": data.content
   });
+  browser.runtime.sendMessage("@notification-sound", "new-notification");
 }
 
 function notifClicked(notifId) {


### PR DESCRIPTION
Support playing a sound with the [notification sound extension](https://addons.mozilla.org/en-US/firefox/addon/notification-sound/?src=external-manga-notifier) whenever a notification is shown.